### PR TITLE
qrexec-client-vm was stripping the escape chars on output.

### DIFF
--- a/bin/qvm-pass
+++ b/bin/qvm-pass
@@ -142,7 +142,10 @@ PASS_MANAGE = "ruddo.PassManage"
 
 
 def send_args(rpc, *args, **kwargs):
-    cmd = ['/usr/lib/qubes/qrexec-client-vm', opts.dest_vm, rpc]
+    cmd = ['/usr/lib/qubes/qrexec-client-vm',
+            '--no-filter-escape-chars-stdout',
+            '--no-filter-escape-chars-stderr',
+            opts.dest_vm, rpc]
 #     print(cmd, file=sys.stderr)
     return_stdout = kwargs.get("return_stdout", False)
     if "return_stdout" in kwargs:

--- a/etc/qubes-rpc/ruddo.PassManage
+++ b/etc/qubes-rpc/ruddo.PassManage
@@ -1,4 +1,9 @@
 #!/bin/bash
+#
+# xterm-256color seems to be the qubes default
+# for gnome-term and Xterm
+#
+export TERM="xterm-256color"
 
 set -e
 set -o pipefail

--- a/etc/qubes-rpc/ruddo.PassRead
+++ b/etc/qubes-rpc/ruddo.PassRead
@@ -1,4 +1,9 @@
 #!/bin/bash
+#
+# xterm-256color seems to be the qubes default
+# for gnome-term and Xterm
+#
+export TERM="xterm-256color"
 
 set -e
 


### PR DESCRIPTION
The server was not aware of the TERM setting, so I made it
explicit, based on common assumptions.  For both gnome-term and
Xterm, the output now matches that of the pass command.
Additionally, `qrexec-client-vm `was stripping the control chars, resulting in garbled output.

```
$ qvm-pass ls
Password Store
└── test
    ├── t0
    ├── t000
    └── t001

```