### PR TITLE
Allow per-domain password stores

### DIFF
--- a/etc/qubes-rpc/ruddo.PassManage
+++ b/etc/qubes-rpc/ruddo.PassManage
@@ -15,10 +15,18 @@ set -o pipefail
 read -n 4096 cmd
 cmd=$(echo "$cmd" | base64 -d)
 
-if [ "$cmd" == "init" ] ; then
+# Try per-domain directories
+PASSWORD_STORE_DIR="$HOME/password-store/$QREXEC_REMOTE_DOMAIN"
+if [ ! -f "$PASSWORD_STORE_DIR/.gpg-id" -a "$cmd" != "domain-init" ]; then
+  # Fallback to default directory
+  PASSWORD_STORE_DIR="$HOME/.password-store"
+fi
+export PASSWORD_STORE_DIR
 
-  if test -f "$HOME"/.password-store/.gpg-id ; then
-      key=$(cat "$HOME"/.password-store/.gpg-id)
+if [ "$cmd" == "init" -o "$cmd" == "domain-init" ] ; then
+
+  if test -f "$PASSWORD_STORE_DIR/.gpg-id" ; then
+      key=$(cat "$PASSWORD_STORE_DIR/.gpg-id")
       echo "Not creating -- password store already exists and uses GPG key $key." >&2
       exit 8
   fi

--- a/etc/qubes-rpc/ruddo.PassRead
+++ b/etc/qubes-rpc/ruddo.PassRead
@@ -11,6 +11,14 @@ export TERM="xterm-256color"
 
 set -e
 
+# Try per-domain directories
+PASSWORD_STORE_DIR="$HOME/password-store/$QREXEC_REMOTE_DOMAIN"
+if [ ! -f "$PASSWORD_STORE_DIR/.gpg-id" ]; then
+  # Fallback to default directory
+  PASSWORD_STORE_DIR="$HOME/.password-store"
+fi
+export PASSWORD_STORE_DIR
+
 read -n 4096 cmd
 cmd=$(echo "$cmd" | base64 -d)
 


### PR DESCRIPTION
This is my first take at implementing per-domain password stores with a fallback to a global (i.e. the current) password store.

I haven't touched qvm-pass yet. Consider it an RFC. What do you think about it?

In this state, a new command `qvm-pass domain-init` may need to get introduced, in order to be able to differentiate between initialization of a global vs. a per-domain store.
